### PR TITLE
Added Doctrine Coding Standard

### DIFF
--- a/.github/workflow/coding-standards.yml
+++ b/.github/workflow/coding-standards.yml
@@ -1,0 +1,20 @@
+name: "Coding Standards"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+      - "main"
+  push:
+    branches:
+      - "*.x"
+      - "main"
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    uses: "doctrine/.github/.github/workflows/coding-standards.yml@1.3.0"
+    with:
+      php-version: '8.0'
+      composer-options: '--prefer-dist --ignore-platform-req=php'
+

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 .DS_Store
 .idea
+.phpcs-cache

--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,6 @@
         "doctrine",
         "debugbar",
         "profiler",
-        "debug",
-        "dev",
         "dbal",
         "middleware",
         "logging"
@@ -30,5 +28,21 @@
         "psr-4": {
             "Cheack\\DebugbarDoctrine\\": "src/"
         }
+    },
+    "require-dev": {
+        "doctrine/coding-standard": "^12.0",
+        "php-parallel-lint/php-parallel-lint": "^1.4",
+        "laravel/framework": "^11.37"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/parallel-lint src",
+            "vendor/bin/phpcs"
+        ]
     }
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset>
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+
+    <!-- Ignore warnings, show progress of the run and show sniff names -->
+    <arg value="nps"/>
+
+    <!-- Directories to be checked -->
+    <file>src</file>
+
+    <!-- Include full Doctrine Coding Standard -->
+    <rule ref="Doctrine"/>
+</ruleset>

--- a/src/Middleware/Connection.php
+++ b/src/Middleware/Connection.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
 
 use Doctrine\DBAL\Driver\Middleware\AbstractConnectionMiddleware;
@@ -10,19 +12,13 @@ class Connection extends AbstractConnectionMiddleware
 {
     use ExecutionTime;
 
-    /**
-     * {@inheritDoc}
-     */
     public function prepare(string $sql): StatementInterface
     {
         return new Statement(parent::prepare($sql), $sql);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     public function query(string $sql): Result
     {
-        return $this->time(fn() => parent::query($sql), $sql);
+        return $this->time(fn () => parent::query($sql), $sql);
     }
 }

--- a/src/Middleware/Driver.php
+++ b/src/Middleware/Driver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
 
 use Doctrine\DBAL\Driver\Middleware\AbstractDriverMiddleware;

--- a/src/Middleware/ExecutionTime.php
+++ b/src/Middleware/ExecutionTime.php
@@ -1,25 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
 
 use Illuminate\Database\Events\QueryExecuted;
+
+use function microtime;
 
 trait ExecutionTime
 {
     /**
      * Measure the execution time of a callable and log it as a query execution event.
-     *
-     * @param  callable   $callable
-     * @param  string     $sql
-     * @param  array|null $params
-     *
-     * @return mixed
      */
-    protected function time(callable $callable, string $sql, ?array $params = null)
+    protected function time(callable $callable, string $sql, array|null $params = null): mixed
     {
-        $start = microtime(true);
+        $start  = microtime(true);
         $result = $callable();
-        $end = microtime(true);
+        $end    = microtime(true);
 
         event(new QueryExecuted($sql, $params ?: [], ($end - $start) * 1000, new StubDatabaseConnection()));
 

--- a/src/Middleware/Middleware.php
+++ b/src/Middleware/Middleware.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
 
 use Doctrine\DBAL\Driver as DriverInterface;
@@ -7,9 +9,6 @@ use Doctrine\DBAL\Driver\Middleware as MiddlewareInterface;
 
 class Middleware implements MiddlewareInterface
 {
-    /**
-     * {@inheritDoc}
-     */
     public function wrap(DriverInterface $driver): DriverInterface
     {
         return new Driver($driver);

--- a/src/Middleware/Statement.php
+++ b/src/Middleware/Statement.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
 
 use Doctrine\DBAL\Driver\Middleware\AbstractStatementMiddleware;
@@ -11,17 +13,13 @@ class Statement extends AbstractStatementMiddleware
 {
     use ExecutionTime;
 
+    /** @var array<mixed> */
     public array $params = [];
 
-    /**
-     * @param StatementInterface $statement
-     * @param string             $sql
-     */
     public function __construct(
         StatementInterface $statement,
         private string $sql,
-    )
-    {
+    ) {
         parent::__construct($statement);
     }
 
@@ -40,6 +38,6 @@ class Statement extends AbstractStatementMiddleware
      */
     public function execute($params = null): Result
     {
-        return $this->time(fn() => parent::execute($params), $this->sql, $this->params);
+        return $this->time(fn () => parent::execute($params), $this->sql, $this->params);
     }
 }

--- a/src/Middleware/StubDatabaseConnection.php
+++ b/src/Middleware/StubDatabaseConnection.php
@@ -1,20 +1,27 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Cheack\DebugbarDoctrine\Middleware;
+
+use Illuminate\Database\Connection;
 
 /**
  * A stub implementation of Laravel's database connection class.
  * This class is used to fulfill the requirement of a database connection
  * when dispatching the `QueryExecuted` event, even though an actual connection
  * is not necessary. It provides a minimal implementation to satisfy the interface.
+ *
+ * phpcs:disable
  */
-class StubDatabaseConnection extends \Illuminate\Database\Connection
+class StubDatabaseConnection extends Connection
 {
     public function __construct()
     {
+        // No need to call the parent constructor
     }
 
-    public function getName()
+    public function getName(): mixed
     {
         return null;
     }


### PR DESCRIPTION
The function call to `event` in ExecutionTime is not included in require-dev.  In addition, all files now conform to the Doctrine Coding Standard.

A new composer function has been added: `composer test` to run phpcs and parallel-lint.